### PR TITLE
ERP als Freie Software unter Linux

### DIFF
--- a/doc/src/linux.md
+++ b/doc/src/linux.md
@@ -1,0 +1,19 @@
+# Freie Software für Linux
+
+Hier sollen weitere Programme gesammelt werden, die für den Einsatz unter Linux zu empfehlen sind.
+Noch immer ist es in vielen Bereichen für Forschung, Wissenschaft und nicht zuletzt auch
+die Wirtschaft – die meist nach dem Studium folgt – an vielen Stellen ein Grund von Freier Software
+wieder abzuweichen weil keine hinreichend bekannten oder unterstützten Anwendungen und Lösungen
+vorliegen. 
+
+Was hier auf der Liste steht ist im Quellcode unter einer freien Lizenz verfügbar.
+
+## kivitendo
+
+Ein ERP für Linux mit genügend Abdeckung für kleinere bis mittlere Unternehmen.
+Diese Anwendung bietet auch Integration mit Freier Banken-Software und wurde
+bereits zur [Absösung des allseitsbekannten SAP eingesetzt](https://media.ccc.de/search/?q=kivitendo).
+
+* Projekt-Link: [kivitendo](http://www.kivitendo.de/)
+* Repoditorium: [auf GitHub](https://github.com/kivitendo/kivitendo-erp)
+* Lizenz: GPL Version 2


### PR DESCRIPTION
… die sogar LaTeX einsetzt. Einfach weil ERP Software in der Lehre eingesetzt wird und sogar die TU von Anfang an eher schlecht als recht mit dem Marktführer SAP arbeitet.

Eine neue Datei weil ich nicht sehe wo es sonst passt.